### PR TITLE
chore(coverage): set consistent coverage thresholds and ignore specific files

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -9,7 +9,8 @@ const config = {
   collectCoverage: true,
   coverageDirectory: '<rootDir>/coverage',
   collectCoverageFrom: ['<rootDir>/src/**/*.ts', '!<rootDir>/**/__tests__/**/*'],
-  coverageThreshold: { global: { branches: 70, functions: 70, lines: 70, statements: -10 } },
+  coverageThreshold: { global: { branches: 80, functions: 80, lines: 80, statements: 80 } },
+  coveragePathIgnorePatterns: ['<rootDir>/src/main.ts', '<rootDir>/src/setup', '\\.module\\.ts'],
 
   moduleFileExtensions: ['js', 'ts', 'json'],
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "nest build",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "test:cov": "jest --coverage --passWithNoTests",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "start:dev": "nest start --watch",


### PR DESCRIPTION
Updates the Jest configuration to improve test coverage handling and exclude specific files from coverage calculations.
